### PR TITLE
Add gopls support

### DIFF
--- a/TabNine.toml
+++ b/TabNine.toml
@@ -38,9 +38,9 @@ command = "hie"
 args = ["--lsp"]
 
 [language.go]
-command = "go-langserver"
-args = ["-mode", "stdio", "-gocodecompletion"]
-install = [["go", "get", "-u", "github.com/sourcegraph/go-langserver"]]
+command = "gopls"
+args = ["serve"]
+install = [["go", "get", "-u", "golang.org/x/tools/cmd/gopls"]]
 
 [language.dart]
 command = "dart_language_server"


### PR DESCRIPTION
I have added gopls support instead of `go-language-server`.
gopls is Golang official language server and it is better than others.