### PR TITLE
make dl_binaries.sh work

### DIFF
--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -3,16 +3,15 @@ set -e
 
 # This script downloads the binaries for the most recent version of TabNine.
 
-version=$(curl -sS https://update.tabnine.com/version)
-targets=(
-    i686-apple-darwin
+version="$(curl -sS https://update.tabnine.com/version)"
+targets='i686-apple-darwin
     x86_64-apple-darwin
     x86_64-unknown-linux-gnu
     x86_64-pc-windows-gnu
     i686-unknown-linux-gnu
-    i686-pc-windows-gnu
-)
-for target in ${targets[@]}
+    i686-pc-windows-gnu'
+
+echo "$targets" | while read target
 do
     mkdir -p binaries/$version/$target
     case $target in


### PR DESCRIPTION
made dl_binaries.sh more posix compliant.
added double ticks to prevent word splitting.